### PR TITLE
fix(calendar): include final-day events in agenda next-week summary

### DIFF
--- a/src/components/pebble-agenda-calendar.ts
+++ b/src/components/pebble-agenda-calendar.ts
@@ -16,7 +16,7 @@ import {
   isSameMonth,
   isPast,
 } from "date-fns";
-import { CalendarEvent } from "../utils/calendar-utils";
+import { CalendarEvent, filterEventsInRange, getNextWeekRange } from "../utils/calendar-utils";
 import { PebbleBaseCalendar } from "./pebble-base-calendar";
 
 @customElement("pebble-agenda-calendar")
@@ -75,32 +75,21 @@ class PebbleAgendaCalendar extends PebbleBaseCalendar {
 
   private generateNextWeekRange() {
     const weekStartsOn = +(this.weekStartsOn ?? 0) as Day;
-    const currentWeekStart = startOfWeek(this.currentDate, { weekStartsOn });
-    const nextWeekStart = addDays(currentWeekStart, 7);
-    const nextWeekEnd = addDays(nextWeekStart, 6);
-    return { start: nextWeekStart, end: nextWeekEnd };
+    return getNextWeekRange(this.currentDate, weekStartsOn);
   }
 
   private getEventsForNextWeek() {
-    const { start, end } = this.generateNextWeekRange();
-    const weekInterval = { start, end };
+    const range = this.generateNextWeekRange();
 
-    return this.events
-      .filter(
-        (event) =>
-          isWithinInterval(event.start, weekInterval) ||
-          isWithinInterval(event.end, weekInterval) ||
-          (event.start <= start && event.end >= end),
-      )
-      .sort((a, b) => {
-        // Sort by start date (oldest first)
-        const dateDiff = a.start.getTime() - b.start.getTime();
-        if (dateDiff !== 0) return dateDiff;
-        // Within same start date, all day before not all day
-        if (a.allDay !== b.allDay) return a.allDay ? -1 : 1;
-        // Otherwise (same start, both allDay or both not), tie-breaker on end date
-        return a.end.getTime() - b.end.getTime();
-      });
+    return filterEventsInRange(this.events, range).sort((a, b) => {
+      // Sort by start date (oldest first)
+      const dateDiff = a.start.getTime() - b.start.getTime();
+      if (dateDiff !== 0) return dateDiff;
+      // Within same start date, all day before not all day
+      if (a.allDay !== b.allDay) return a.allDay ? -1 : 1;
+      // Otherwise (same start, both allDay or both not), tie-breaker on end date
+      return a.end.getTime() - b.end.getTime();
+    });
   }
 
   private handleCalendarNavigated = (event: CustomEvent) => {

--- a/src/utils/__tests__/calendar-utils.test.ts
+++ b/src/utils/__tests__/calendar-utils.test.ts
@@ -1,4 +1,9 @@
-import { getEventPosition, CalendarEvent } from "../calendar-utils";
+import {
+  CalendarEvent,
+  filterEventsInRange,
+  getEventPosition,
+  getNextWeekRange,
+} from "../calendar-utils";
 
 // Helper function to create a CalendarEvent for testing
 const createEvent = (
@@ -206,5 +211,145 @@ describe("getEventPosition", () => {
       expect(position2.width).toBe(100); // Full width
       expect(position2.left).toBe(0); // 0% offset
     });
+  });
+});
+
+// Helper to build a calendar event on an arbitrary date
+const eventOn = (
+  title: string,
+  start: Date,
+  end: Date,
+  allDay: boolean = false,
+): CalendarEvent => ({
+  title,
+  start,
+  end,
+  daysInterval: 0,
+  calendar: "test-calendar",
+  allDay,
+  eventData: {
+    summary: title,
+    dtstart: start.toISOString(),
+    dtend: end.toISOString(),
+  },
+});
+
+describe("getNextWeekRange", () => {
+  test("when week starts on Monday, end covers the full Sunday including evening", () => {
+    // Wednesday 2026-06-03
+    const currentDate = new Date(2026, 5, 3);
+    const { start, end } = getNextWeekRange(currentDate, 1);
+
+    // Next week starts Monday 2026-06-08 at 00:00
+    expect(start.getDay()).toBe(1);
+    expect(start.getDate()).toBe(8);
+    expect(start.getHours()).toBe(0);
+    expect(start.getMinutes()).toBe(0);
+
+    // Next week ends Sunday 2026-06-14 at end-of-day
+    expect(end.getDay()).toBe(0);
+    expect(end.getDate()).toBe(14);
+    expect(end.getHours()).toBe(23);
+    expect(end.getMinutes()).toBe(59);
+  });
+
+  test("when week starts on Sunday, end covers the full Saturday including evening", () => {
+    // Tuesday 2026-06-02
+    const currentDate = new Date(2026, 5, 2);
+    const { start, end } = getNextWeekRange(currentDate, 0);
+
+    // Next week starts Sunday 2026-06-07 at 00:00
+    expect(start.getDay()).toBe(0);
+    expect(start.getDate()).toBe(7);
+
+    // Next week ends Saturday 2026-06-13 at end-of-day
+    expect(end.getDay()).toBe(6);
+    expect(end.getDate()).toBe(13);
+    expect(end.getHours()).toBe(23);
+  });
+});
+
+describe("filterEventsInRange (regression for Sunday exclusion)", () => {
+  test("includes timed events on the final day of a Monday-starting week", () => {
+    // Wednesday 2026-06-03 => next week is Mon 06-08 to Sun 06-14
+    const range = getNextWeekRange(new Date(2026, 5, 3), 1);
+
+    const sundayMorning = eventOn(
+      "Sunday brunch",
+      new Date(2026, 5, 14, 10, 0),
+      new Date(2026, 5, 14, 12, 0),
+    );
+    const sundayEvening = eventOn(
+      "Sunday dinner",
+      new Date(2026, 5, 14, 18, 0),
+      new Date(2026, 5, 14, 20, 0),
+    );
+
+    const filtered = filterEventsInRange([sundayMorning, sundayEvening], range);
+
+    expect(filtered).toContain(sundayMorning);
+    expect(filtered).toContain(sundayEvening);
+  });
+
+  test("includes timed events on the final day of a Sunday-starting week", () => {
+    // Tuesday 2026-06-02 => next week is Sun 06-07 to Sat 06-13
+    const range = getNextWeekRange(new Date(2026, 5, 2), 0);
+
+    const saturdayEvening = eventOn(
+      "Saturday party",
+      new Date(2026, 5, 13, 19, 0),
+      new Date(2026, 5, 13, 23, 0),
+    );
+
+    const filtered = filterEventsInRange([saturdayEvening], range);
+
+    expect(filtered).toContain(saturdayEvening);
+  });
+
+  test("includes all-day events on the final day of the week", () => {
+    const range = getNextWeekRange(new Date(2026, 5, 3), 1);
+
+    // All-day Sunday event (HA normalizes allDay end to end-of-day)
+    const sundayAllDay = eventOn(
+      "Sunday all-day",
+      new Date(2026, 5, 14, 0, 0),
+      new Date(2026, 5, 14, 23, 59, 59),
+      true,
+    );
+
+    expect(filterEventsInRange([sundayAllDay], range)).toContain(sundayAllDay);
+  });
+
+  test("excludes events fully outside the range", () => {
+    const range = getNextWeekRange(new Date(2026, 5, 3), 1);
+
+    // The week before next week
+    const earlierEvent = eventOn(
+      "Earlier",
+      new Date(2026, 5, 5, 10, 0),
+      new Date(2026, 5, 5, 11, 0),
+    );
+    // The week after next week
+    const laterEvent = eventOn(
+      "Later",
+      new Date(2026, 5, 16, 10, 0),
+      new Date(2026, 5, 16, 11, 0),
+    );
+
+    const filtered = filterEventsInRange([earlierEvent, laterEvent], range);
+    expect(filtered).not.toContain(earlierEvent);
+    expect(filtered).not.toContain(laterEvent);
+  });
+
+  test("includes events that fully span the range", () => {
+    const range = getNextWeekRange(new Date(2026, 5, 3), 1);
+
+    const spanning = eventOn(
+      "Conference",
+      new Date(2026, 5, 1, 9, 0),
+      new Date(2026, 5, 20, 17, 0),
+    );
+
+    expect(filterEventsInRange([spanning], range)).toContain(spanning);
   });
 });

--- a/src/utils/calendar-utils.ts
+++ b/src/utils/calendar-utils.ts
@@ -1,14 +1,18 @@
 import {
+  addDays,
   differenceInCalendarDays,
   endOfDay,
+  isWithinInterval,
   parseISO,
   startOfDay,
+  startOfWeek,
   subDays,
   max,
   min,
   eachDayOfInterval,
   getHours,
   getMinutes,
+  Day,
 } from "date-fns";
 import type { HomeAssistant } from "../types";
 
@@ -149,6 +153,37 @@ export const getTimeUntilNextInterval = (intervalMinutes: number, now: Date = ne
   const totalSeconds = totalMinutes - seconds;
 
   return totalSeconds * 1_000 - milliseconds;
+};
+
+/**
+ * Returns the date range for the week following the week containing `currentDate`.
+ * `end` is the end of the last day (23:59:59.999) so timed events on the final
+ * day of the week are not excluded by inclusive interval checks.
+ */
+export const getNextWeekRange = (
+  currentDate: Date,
+  weekStartsOn: Day,
+): { start: Date; end: Date } => {
+  const currentWeekStart = startOfWeek(currentDate, { weekStartsOn });
+  const nextWeekStart = addDays(currentWeekStart, 7);
+  const nextWeekEnd = endOfDay(addDays(nextWeekStart, 6));
+  return { start: nextWeekStart, end: nextWeekEnd };
+};
+
+/**
+ * Returns events that overlap the given date range. An event overlaps if it
+ * starts within the range, ends within the range, or fully spans the range.
+ */
+export const filterEventsInRange = (
+  events: ReadonlyArray<CalendarEvent>,
+  range: { start: Date; end: Date },
+): CalendarEvent[] => {
+  return events.filter(
+    (event) =>
+      isWithinInterval(event.start, range) ||
+      isWithinInterval(event.end, range) ||
+      (event.start <= range.start && event.end >= range.end),
+  );
 };
 
 export const getEventsByWeekdays = (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "bundler",
+    "ignoreDeprecations": "6.0",
     "noEmitOnError": true,
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "strict": true,


### PR DESCRIPTION
The agenda next-week summary computed its range end as `addDays(nextWeekStart, 6)`, which resolves to 00:00 of the last day. Because events are filtered with `isWithinInterval`, any timed event later than midnight on that final day was excluded. With a Monday week start the final day is Sunday, so Sunday's timed events were dropped from both the bar chart counts and the total.

Also set `ignoreDeprecations: "6.0"` in tsconfig so the test suite can run under the lockfile-pinned TypeScript 6.0.3 (ts-jest injects the now hard-deprecated node10 module resolution, which otherwise aborts emit).